### PR TITLE
Update .quartoignore

### DIFF
--- a/.quartoignore
+++ b/.quartoignore
@@ -1,3 +1,3 @@
-tex
+
 example.tex
 example.pdf


### PR DESCRIPTION
When using 'quarto use template' in the Command Prompt, the template doesn't work because the tex folder is not included.